### PR TITLE
Fix scrollbars displayed in Java - see #9

### DIFF
--- a/sass/_dronekit.scss
+++ b/sass/_dronekit.scss
@@ -11,7 +11,7 @@ h2{
 .highlight-java{
 	width: 100%;
 	max-width: 800px;
-	overflow: scroll;
+	overflow: auto;
 }
 
 pre{


### PR DESCRIPTION
All this does is change the overflow from "scroll" to "auto" - so the scroll bars are displayed when needed, not by default. 

Note that I tested this locally by modifying the CSS, but I can't test this "end to end" because I can't get this project to build.

Also, @mrpollo , can you push a new version of this to PIP?
